### PR TITLE
Add animated speed HUD with gauge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "speedometer",
       "version": "1.0.0",
       "dependencies": {
+        "framer-motion": "^12.18.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.17.0"
@@ -6428,6 +6429,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.18.1.tgz",
+      "integrity": "sha512-6o4EDuRPLk4LSZ1kRnnEOurbQ86MklVk+Y1rFBUKiF+d2pCdvMjWVu0ZkyMVCTwl5UyTH2n/zJEJx+jvTYuxow==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.18.1",
+        "motion-utils": "^12.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9487,6 +9515,21 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.18.1.tgz",
+      "integrity": "sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.18.1.tgz",
+      "integrity": "sha512-az26YDU4WoDP0ueAkUtABLk2BIxe28d8NH1qWT8jPGhPyf44XTdDUh8pDk9OPphaSrR9McgpcJlgwSOIw/sfkA==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11597,6 +11640,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.17.0"
+    "react-router-dom": "^6.17.0",
+    "framer-motion": "^12.18.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/components/free/FreeDashboard.jsx
+++ b/src/components/free/FreeDashboard.jsx
@@ -1,14 +1,19 @@
-import HUD from './HUD'
+import SpeedHUD from '../ui/SpeedHUD'
+import Gauge from '../ui/Gauge'
 import SpeedAlert from './SpeedAlert'
 import TripSummary from './TripSummary'
 import AdBanner from './AdBanner'
 import UnitToggle from './UnitToggle'
 import { useTheme } from '../../context/ThemeContext'
+import { useUnit } from '../../context/UnitContext'
+import useSpeed from '../../hooks/useSpeed'
 
 export default function FreeDashboard() {
+  const { unit } = useUnit()
+  const { speed } = useSpeed(unit)
   const { dark, setDark } = useTheme()
   return (
-    <div className="max-w-sm mx-auto p-2">
+    <div className="max-w-sm mx-auto p-2 space-y-4">
       <div className="flex justify-between items-center space-x-2">
         <h1 className="text-xl font-bold">Free Speedometer</h1>
         <UnitToggle />
@@ -16,7 +21,8 @@ export default function FreeDashboard() {
           {dark ? 'Day' : 'Night'}
         </button>
       </div>
-      <HUD />
+      <SpeedHUD />
+      <Gauge value={speed} />
       <SpeedAlert />
       <TripSummary />
       <AdBanner />

--- a/src/components/free/__tests__/HUD.test.jsx
+++ b/src/components/free/__tests__/HUD.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import HUD from '../HUD'
+import SpeedHUD from '../../ui/SpeedHUD'
 import { UnitProvider } from '../../../context/UnitContext'
 
 jest.mock('../../../hooks/useSpeed', () => () => ({ speed: 0, distance: 0, duration: 0, avgSpeed: 0, error: null }))
@@ -8,7 +8,7 @@ jest.mock('../../../hooks/useSpeed', () => () => ({ speed: 0, distance: 0, durat
 test('renders speed display with unit', () => {
   render(
     <UnitProvider>
-      <HUD />
+      <SpeedHUD />
     </UnitProvider>
   )
   expect(screen.getByTestId('speed-display').textContent).toContain('km/h')

--- a/src/components/ui/Gauge.jsx
+++ b/src/components/ui/Gauge.jsx
@@ -1,0 +1,23 @@
+import { motion, useMotionValue, animate } from 'framer-motion'
+import { useEffect } from 'react'
+
+export default function Gauge({ value = 0, max = 180 }) {
+  const angle = useMotionValue(-90)
+
+  useEffect(() => {
+    const target = -90 + Math.min(value, max) / max * 180
+    const controls = animate(angle, target, { duration: 0.5, ease: 'easeInOut' })
+    return controls.stop
+  }, [value, max, angle])
+
+  return (
+    <div className="glass rounded-lg p-4">
+      <svg viewBox="0 0 100 50" className="w-full max-w-xs mx-auto">
+        <path d="M5 45 A45 45 0 0 1 95 45" fill="none" stroke="#555" strokeWidth="4" />
+        <motion.g style={{ originX: '50%', originY: '45%', rotate: angle }}>
+          <line x1="50" y1="45" x2="50" y2="15" stroke="currentColor" strokeWidth="4" />
+        </motion.g>
+      </svg>
+    </div>
+  )
+}

--- a/src/components/ui/SpeedHUD.jsx
+++ b/src/components/ui/SpeedHUD.jsx
@@ -1,0 +1,28 @@
+import { motion, useMotionValue, useMotionValueEvent, animate } from 'framer-motion'
+import { useEffect, useState } from 'react'
+import useSpeed from '../../hooks/useSpeed'
+import { useUnit } from '../../context/UnitContext'
+
+export default function SpeedHUD() {
+  const { unit } = useUnit()
+  const { speed, error } = useSpeed(unit)
+  const unitLabel = unit === 'kmh' ? 'km/h' : 'mph'
+
+  const value = useMotionValue(0)
+  const [display, setDisplay] = useState(0)
+  useMotionValueEvent(value, 'change', v => setDisplay(v))
+
+  useEffect(() => {
+    const controls = animate(value, speed, { duration: 0.5, ease: 'easeInOut' })
+    return controls.stop
+  }, [speed, value])
+
+  return (
+    <div className="flex flex-col items-center p-4 glass rounded-lg">
+      {error && <div className="text-red-500 text-sm mb-2">{error}</div>}
+      <motion.div data-testid="speed-display" className="text-6xl font-mono text-neon-green font-bold">
+        {display.toFixed(1)} {unitLabel}
+      </motion.div>
+    </div>
+  )
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .text-neon-green {
+    @apply text-green-400 drop-shadow-[0_0_6px_rgba(0,255,0,0.7)];
+  }
+  .glass {
+    @apply bg-white/10 backdrop-blur-md backdrop-saturate-150;
+  }
+}


### PR DESCRIPTION
## Summary
- add framer-motion to dependencies
- implement `SpeedHUD` with animated digits and glowing neon style
- create `Gauge` component with animated needle
- use new HUD and gauge in `FreeDashboard`
- add custom neon and glass utilities
- update test to mount `SpeedHUD`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853ed165c248325ac580893a3632fa1