### PR TITLE
Add theme toggle with transition

### DIFF
--- a/src/components/free/FreeDashboard.jsx
+++ b/src/components/free/FreeDashboard.jsx
@@ -3,18 +3,15 @@ import SpeedAlert from './SpeedAlert'
 import TripSummary from './TripSummary'
 import AdBanner from './AdBanner'
 import UnitToggle from './UnitToggle'
-import { useTheme } from '../../context/ThemeContext'
+import ThemeToggle from '../ui/ThemeToggle'
 
 export default function FreeDashboard() {
-  const { dark, setDark } = useTheme()
   return (
     <div className="max-w-sm mx-auto p-2">
       <div className="flex justify-between items-center space-x-2">
         <h1 className="text-xl font-bold">Free Speedometer</h1>
         <UnitToggle />
-        <button onClick={() => setDark(!dark)} className="text-sm border rounded px-2 py-1">
-          {dark ? 'Day' : 'Night'}
-        </button>
+        <ThemeToggle />
       </div>
       <HUD />
       <SpeedAlert />

--- a/src/components/ui/ThemeToggle.jsx
+++ b/src/components/ui/ThemeToggle.jsx
@@ -1,0 +1,13 @@
+import { useTheme } from '../../context/ThemeContext'
+
+export default function ThemeToggle() {
+  const { dark, setDark } = useTheme()
+  return (
+    <button
+      onClick={() => setDark(!dark)}
+      className="text-sm border rounded px-2 py-1 transition-colors duration-500"
+    >
+      {dark ? 'Day' : 'Night'}
+    </button>
+  )
+}

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -6,7 +6,13 @@ export function ThemeProvider({ children }) {
   const [dark, setDark] = useState(false)
   return (
     <ThemeContext.Provider value={{ dark, setDark }}>
-      <div className={dark ? 'dark' : ''}>{children}</div>
+      <div
+        className={`min-h-screen transition-colors duration-500 ${
+          dark ? 'dark bg-gray-900 text-gray-100' : 'bg-gray-100 text-gray-900'
+        }`}
+      >
+        {children}
+      </div>
     </ThemeContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary
- create `ThemeToggle` button component
- add transition styles in `ThemeProvider` for smooth light/dark switching
- use `ThemeToggle` in `FreeDashboard` to control theme

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853fc8e4d2c8325a1cfb91d388cd988