### PR TITLE
Add TripInfo terminal widget

### DIFF
--- a/src/components/free/FreeDashboard.jsx
+++ b/src/components/free/FreeDashboard.jsx
@@ -3,12 +3,14 @@ import SpeedAlert from './SpeedAlert'
 import TripSummary from './TripSummary'
 import AdBanner from './AdBanner'
 import UnitToggle from './UnitToggle'
+import TripInfo from '../ui/TripInfo'
+import AROverlay from '../ui/AROverlay'
 import { useTheme } from '../../context/ThemeContext'
 
 export default function FreeDashboard() {
   const { dark, setDark } = useTheme()
   return (
-    <div className="max-w-sm mx-auto p-2">
+    <div className="max-w-sm mx-auto p-2 relative">
       <div className="flex justify-between items-center space-x-2">
         <h1 className="text-xl font-bold">Free Speedometer</h1>
         <UnitToggle />
@@ -19,7 +21,9 @@ export default function FreeDashboard() {
       <HUD />
       <SpeedAlert />
       <TripSummary />
+      <TripInfo />
       <AdBanner />
+      <AROverlay />
     </div>
   )
 }

--- a/src/components/ui/AROverlay.jsx
+++ b/src/components/ui/AROverlay.jsx
@@ -1,0 +1,7 @@
+export default function AROverlay() {
+  return (
+    <div className="absolute inset-0 pointer-events-none flex items-center justify-center bg-black/20 text-white text-2xl">
+      AR Overlay
+    </div>
+  )
+}

--- a/src/components/ui/TripInfo.jsx
+++ b/src/components/ui/TripInfo.jsx
@@ -1,0 +1,40 @@
+import useSpeed from '../../hooks/useSpeed'
+import { useUnit } from '../../context/UnitContext'
+import { useState, useEffect } from 'react'
+
+function useAnimatedNumber(value, duration = 400) {
+  const [display, setDisplay] = useState(value)
+  useEffect(() => {
+    let start = display
+    let startTime
+    function step(t) {
+      if (!startTime) startTime = t
+      const progress = Math.min((t - startTime) / duration, 1)
+      setDisplay(start + (value - start) * progress)
+      if (progress < 1) requestAnimationFrame(step)
+    }
+    requestAnimationFrame(step)
+  }, [value, duration])
+  return display
+}
+
+export default function TripInfo() {
+  const { unit } = useUnit()
+  const { speed, distance, duration, avgSpeed } = useSpeed(unit)
+  const dist = unit === 'kmh' ? distance / 1000 : distance / 1609.34
+  const speedUnit = unit === 'kmh' ? 'km/h' : 'mph'
+  const distUnit = unit === 'kmh' ? 'km' : 'mi'
+  const dispSpeed = useAnimatedNumber(speed)
+  const dispAvg = useAnimatedNumber(avgSpeed)
+  const dispDist = useAnimatedNumber(dist)
+  const dispDur = useAnimatedNumber(duration)
+
+  return (
+    <div className="bg-black/80 text-green-500 font-mono text-xs p-2 rounded leading-tight space-y-0.5">
+      <div>Speed: {dispSpeed.toFixed(1)} {speedUnit}</div>
+      <div>Avg: {dispAvg.toFixed(1)} {speedUnit}</div>
+      <div>Dist: {dispDist.toFixed(2)} {distUnit}</div>
+      <div>Time: {Math.floor(dispDur)} s</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `TripInfo` terminal-style widget with animated numbers
- add `AROverlay` placeholder component
- include widgets in `FreeDashboard`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685402f7ae5883258685f79765c23d1e