### PR TITLE
Fix Babel config for nativewind

### DIFF
--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,7 +1,6 @@
 module.exports = function (api) {
   api.cache(true)
   return {
-    presets: ['babel-preset-expo'],
-    plugins: ['nativewind/babel'],
+    presets: ['babel-preset-expo', 'nativewind/babel'],
   }
 }


### PR DESCRIPTION
## Summary
- use `nativewind/babel` as a preset instead of plugin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859fd8cbd748325964dfd4252d343a6