### PR TITLE
Fix Expo config plugin error

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -14,7 +14,6 @@
     "android": {
       "permissions": ["ACCESS_FINE_LOCATION"],
       "package": "com.example.speedometer"
-    },
-    "plugins": ["nativewind"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- remove `nativewind` from the Expo plugins list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a04d8cd5c832587417daad19cb49c