### PR TITLE
Fix distance calculation for mobile

### DIFF
--- a/mobile/hooks/useSpeed.ts
+++ b/mobile/hooks/useSpeed.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react'
 import * as Location from 'expo-location'
+import { haversineDistance } from '../utils/geo'
 import { Unit } from '../context/UnitContext'
 
 export default function useSpeed(unit: Unit) {
@@ -23,9 +24,11 @@ export default function useSpeed(unit: Unit) {
           const { speed, latitude, longitude } = pos.coords
           setSpeedMs(speed ?? 0)
           if (lastPos.current) {
-            const d = Location.distance(
-              { latitude, longitude },
-              { latitude: lastPos.current.latitude, longitude: lastPos.current.longitude }
+            const d = haversineDistance(
+              lastPos.current.latitude,
+              lastPos.current.longitude,
+              latitude,
+              longitude
             )
             setDistance(prev => prev + d)
           }

--- a/mobile/utils/geo.ts
+++ b/mobile/utils/geo.ts
@@ -1,0 +1,16 @@
+export function haversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+): number {
+  const R = 6371000; // meters
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}


### PR DESCRIPTION
## Summary
- calculate distance using a new `haversineDistance` helper
- replace undefined `Location.distance` calls with the helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a09f57a808325965d594750010d42