### PR TITLE
Add futuristic HUD overhaul

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Speedometer</title>
   </head>
-  <body class="bg-gray-100 text-gray-900">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -7,26 +7,36 @@ import UnitToggle from './components/UnitToggle'
 import ThemeToggle from './components/ThemeToggle'
 import TripSummary from './components/TripSummary'
 import AdBanner from './components/AdBanner'
+import HUDToggle from './components/HUDToggle'
 import { UnitProvider } from './context/UnitContext'
 import { ThemeProvider, useTheme } from './context/ThemeContext'
 import { SpeedProvider } from './context/SpeedContext'
+import { HUDProvider, useHUD } from './context/HUDContext'
 import { StatusBar } from 'expo-status-bar'
 
 function Dashboard() {
   const { dark } = useTheme()
+  const { hud } = useHUD()
   return (
     <SafeAreaView className={dark ? 'bg-black flex-1' : 'bg-white flex-1'}>
-      <ScrollView contentContainerStyle={{ padding: 16 }}>
-        <View className="flex-row justify-between items-center mb-4">
-          <UnitToggle />
-          <ThemeToggle />
+      {hud ? (
+        <View className="flex-1 items-center justify-center">
+          <SpeedHUD />
         </View>
-        <SpeedHUD />
-        <Gauge />
-        <SpeedAlert />
-        <TripSummary />
-        <AdBanner />
-      </ScrollView>
+      ) : (
+        <ScrollView contentContainerStyle={{ padding: 16 }}>
+          <View className="flex-row justify-between items-center mb-4 space-x-2">
+            <UnitToggle />
+            <HUDToggle />
+            <ThemeToggle />
+          </View>
+          <SpeedHUD />
+          <Gauge />
+          <SpeedAlert />
+          <TripSummary />
+          <AdBanner />
+        </ScrollView>
+      )}
       <StatusBar style={dark ? 'light' : 'dark'} />
     </SafeAreaView>
   )
@@ -36,9 +46,11 @@ export default function App() {
   return (
     <ThemeProvider>
       <UnitProvider>
-        <SpeedProvider>
-          <Dashboard />
-        </SpeedProvider>
+        <HUDProvider>
+          <SpeedProvider>
+            <Dashboard />
+          </SpeedProvider>
+        </HUDProvider>
       </UnitProvider>
     </ThemeProvider>
   )

--- a/mobile/components/HUDToggle.tsx
+++ b/mobile/components/HUDToggle.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Button } from 'react-native'
+import { useHUD } from '../context/HUDContext'
+
+export default function HUDToggle() {
+  const { hud, toggleHUD } = useHUD()
+  return <Button title={hud ? 'Dashboard' : 'HUD'} onPress={toggleHUD} />
+}

--- a/mobile/components/SpeedHUD.tsx
+++ b/mobile/components/SpeedHUD.tsx
@@ -1,18 +1,28 @@
-import React from 'react'
-import { Text, View } from 'react-native'
+import React, { useState } from 'react'
+import { View, Text } from 'react-native'
+import { MotiText } from 'moti'
 import { useUnit } from '../context/UnitContext'
 import { useSpeedContext } from '../context/SpeedContext'
 
 export default function SpeedHUD() {
   const { unit } = useUnit()
   const { speed, error } = useSpeedContext()
+  const [key, setKey] = useState(0)
+  React.useEffect(() => setKey(k => k + 1), [speed])
   const unitLabel = unit === 'kmh' ? 'km/h' : 'mph'
   return (
     <View className="items-center p-4">
       {error && <Text className="text-red-500 mb-2 text-sm">{error}</Text>}
-      <Text testID="speed-display" className="text-6xl font-bold">
+      <MotiText
+        key={key}
+        from={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ type: 'timing', duration: 200 }}
+        testID="speed-display"
+        className="text-7xl font-bold text-green-400"
+      >
         {speed.toFixed(1)} {unitLabel}
-      </Text>
+      </MotiText>
     </View>
   )
 }

--- a/mobile/context/HUDContext.tsx
+++ b/mobile/context/HUDContext.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, useState } from 'react'
+
+interface HUDContextProps {
+  hud: boolean
+  toggleHUD: () => void
+}
+
+const HUDContext = createContext<HUDContextProps | undefined>(undefined)
+
+export const HUDProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [hud, setHUD] = useState(false)
+  const toggleHUD = () => setHUD(h => !h)
+  return <HUDContext.Provider value={{ hud, toggleHUD }}>{children}</HUDContext.Provider>
+}
+
+export const useHUD = () => {
+  const ctx = useContext(HUDContext)
+  if (!ctx) throw new Error('useHUD must be used within HUDProvider')
+  return ctx
+}

--- a/mobile/context/SpeedContext.tsx
+++ b/mobile/context/SpeedContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react'
+import React, { createContext, useContext, useState } from 'react'
 import useSpeed from '../hooks/useSpeed'
 import { useUnit } from './UnitContext'
 
@@ -8,6 +8,7 @@ export interface SpeedData {
   duration: number
   avgSpeed: number
   error: string | null
+  setSpeed?: (v: number | null) => void
 }
 
 const SpeedContext = createContext<SpeedData | undefined>(undefined)
@@ -15,7 +16,13 @@ const SpeedContext = createContext<SpeedData | undefined>(undefined)
 export const SpeedProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { unit } = useUnit()
   const data = useSpeed(unit)
-  return <SpeedContext.Provider value={data}>{children}</SpeedContext.Provider>
+  const [override, setOverride] = useState<number | null>(null)
+  const value = {
+    ...data,
+    speed: override !== null ? override : data.speed,
+    setSpeed: setOverride,
+  }
+  return <SpeedContext.Provider value={value}>{children}</SpeedContext.Provider>
 }
 
 export const useSpeedContext = () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,17 +2,20 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import FreeDashboard from './components/free/FreeDashboard'
 import { ThemeProvider } from './context/ThemeContext'
 import { UnitProvider } from './context/UnitContext'
+import { HUDProvider } from './context/HUDContext'
 
 export default function App() {
   return (
     <ThemeProvider>
       <UnitProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Navigate to="/free" />} />
-            <Route path="/free" element={<FreeDashboard />} />
-          </Routes>
-        </BrowserRouter>
+        <HUDProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<Navigate to="/free" />} />
+              <Route path="/free" element={<FreeDashboard />} />
+            </Routes>
+          </BrowserRouter>
+        </HUDProvider>
       </UnitProvider>
     </ThemeProvider>
   )

--- a/src/components/free/FreeDashboard.jsx
+++ b/src/components/free/FreeDashboard.jsx
@@ -1,18 +1,33 @@
+import React from 'react'
 import SpeedHUD from '../ui/SpeedHUD'
 import Gauge from '../ui/Gauge'
 import SpeedAlert from './SpeedAlert'
 import TripSummary from './TripSummary'
 import AdBanner from './AdBanner'
 import UnitToggle from './UnitToggle'
+import HUDToggle from './HUDToggle'
 import TripInfo from '../ui/TripInfo'
 import AROverlay from '../ui/AROverlay'
 import ThemeToggle from '../ui/ThemeToggle'
 import { motion } from 'framer-motion'
 import { sweep } from '../../hooks/useAnimations'
 import { SpeedProvider, useSpeedContext } from '../../context/SpeedContext'
+import { useHUD } from '../../context/HUDContext'
+import { useUnit } from '../../context/UnitContext'
 
 function DashboardContent() {
-  const { speed } = useSpeedContext()
+  const { speed, setSpeed } = useSpeedContext()
+  const { hud, toggleHUD } = useHUD()
+  const { toggleUnit } = useUnit()
+
+  React.useEffect(() => {
+    function handle(e) {
+      if (e.key === 'u') toggleUnit()
+      if (e.key === 'h') toggleHUD()
+    }
+    window.addEventListener('keydown', handle)
+    return () => window.removeEventListener('keydown', handle)
+  }, [toggleHUD, toggleUnit])
 
   return (
     <motion.div
@@ -21,20 +36,37 @@ function DashboardContent() {
       initial="initial"
       animate="animate"
     >
-      <div className="max-w-sm mx-auto p-2 relative space-y-4">
-        <div className="flex justify-between items-center space-x-2">
-          <h1 className="text-xl font-bold">Free Speedometer</h1>
-          <UnitToggle />
-          <ThemeToggle />
+      {hud ? (
+        <div className="h-screen flex items-center justify-center">
+          <SpeedHUD />
         </div>
-        <SpeedHUD />
-        <Gauge value={speed} />
-        <SpeedAlert />
-        <TripSummary />
-        <TripInfo />
-        <AdBanner />
-        <AROverlay />
-      </div>
+      ) : (
+        <div className="max-w-sm mx-auto p-2 relative space-y-4">
+          <div className="flex justify-between items-center space-x-2">
+            <h1 className="text-xl font-bold">Free Speedometer</h1>
+            <UnitToggle />
+            <HUDToggle />
+            <ThemeToggle />
+          </div>
+          <SpeedHUD />
+          <Gauge value={speed} />
+          <div className="p-4">
+            <input
+              type="range"
+              min="0"
+              max="200"
+              value={speed}
+              onChange={e => setSpeed(Number(e.target.value))}
+              className="w-full"
+            />
+          </div>
+          <SpeedAlert />
+          <TripSummary />
+          <TripInfo />
+          <AdBanner />
+          <AROverlay />
+        </div>
+      )}
     </motion.div>
   )
 }

--- a/src/components/free/HUDToggle.jsx
+++ b/src/components/free/HUDToggle.jsx
@@ -1,0 +1,18 @@
+import { useHUD } from '../../context/HUDContext'
+import { motion } from 'framer-motion'
+import { fade } from '../../hooks/useAnimations'
+
+export default function HUDToggle() {
+  const { hud, toggleHUD } = useHUD()
+  return (
+    <motion.button
+      onClick={toggleHUD}
+      className="text-sm border rounded px-2 py-1"
+      variants={fade}
+      initial="initial"
+      animate="animate"
+    >
+      {hud ? 'Dashboard' : 'HUD'}
+    </motion.button>
+  )
+}

--- a/src/context/HUDContext.jsx
+++ b/src/context/HUDContext.jsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, useState } from 'react'
+
+const HUDContext = createContext()
+
+export function HUDProvider({ children }) {
+  const [hud, setHUD] = useState(false)
+  const toggleHUD = () => setHUD(h => !h)
+  return (
+    <HUDContext.Provider value={{ hud, toggleHUD }}>
+      {children}
+    </HUDContext.Provider>
+  )
+}
+
+export function useHUD() {
+  return useContext(HUDContext)
+}

--- a/src/context/SpeedContext.jsx
+++ b/src/context/SpeedContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, useContext, useState } from 'react'
 import useSpeed from '../hooks/useSpeed'
 import { useUnit } from './UnitContext'
 
@@ -7,8 +7,14 @@ const SpeedContext = createContext(null)
 export function SpeedProvider({ children }) {
   const { unit } = useUnit()
   const data = useSpeed(unit)
+  const [override, setOverride] = useState(null)
+  const value = {
+    ...data,
+    speed: override !== null ? override : data.speed,
+    setSpeed: setOverride
+  }
   return (
-    <SpeedContext.Provider value={data}>
+    <SpeedContext.Provider value={value}>
       {children}
     </SpeedContext.Provider>
   )

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -13,3 +13,7 @@
 
 @import './tailwind.custom.css';
 
+body {
+  @apply bg-gradient-to-br from-black via-gray-900 to-gray-800 text-gray-100;
+}
+


### PR DESCRIPTION
## Summary
- animate speed display using Moti
- add HUD toggle and provider for mobile and web
- add optional simulated speed slider on web
- allow keyboard shortcuts for HUD and unit changes
- style body with dark gradient background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a0db957b08325b355fb917a1026c6