### PR TITLE
Add Orbitron font

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Speedometer</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -14,6 +14,6 @@
 @import './tailwind.custom.css';
 
 body {
-  @apply bg-gradient-to-br from-black via-gray-900 to-gray-800 text-gray-100;
+  @apply font-digital bg-gradient-to-br from-black via-gray-900 to-gray-800 text-gray-100;
 }
 


### PR DESCRIPTION
## Summary
- add link tag for Google Orbitron font
- apply `font-digital` class in global stylesheet

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a13344160832587b8d6a8b79b4038