### PR TITLE
Add maxSpeed tracking

### DIFF
--- a/mobile/components/TripSummary.tsx
+++ b/mobile/components/TripSummary.tsx
@@ -5,7 +5,7 @@ import { useSpeedContext } from '../context/SpeedContext'
 
 export default function TripSummary() {
   const { unit } = useUnit()
-  const { distance, duration, avgSpeed } = useSpeedContext()
+  const { distance, duration, avgSpeed, maxSpeed } = useSpeedContext()
   const dist = unit === 'kmh' ? distance / 1000 : distance / 1609.34
   const distUnit = unit === 'kmh' ? 'km' : 'mi'
   const speedUnit = unit === 'kmh' ? 'km/h' : 'mph'
@@ -14,6 +14,7 @@ export default function TripSummary() {
       <Text>Distance: {dist.toFixed(2)} {distUnit}</Text>
       <Text>Duration: {Math.floor(duration)} s</Text>
       <Text>Avg: {avgSpeed.toFixed(1)} {speedUnit}</Text>
+      <Text>Max: {maxSpeed.toFixed(1)} {speedUnit}</Text>
     </View>
   )
 }

--- a/mobile/context/SpeedContext.tsx
+++ b/mobile/context/SpeedContext.tsx
@@ -4,6 +4,7 @@ import { useUnit } from './UnitContext'
 
 export interface SpeedData {
   speed: number
+  maxSpeed: number
   distance: number
   duration: number
   avgSpeed: number

--- a/mobile/hooks/useSpeed.ts
+++ b/mobile/hooks/useSpeed.ts
@@ -5,6 +5,7 @@ import { Unit } from '../context/UnitContext'
 
 export default function useSpeed(unit: Unit) {
   const [speedMs, setSpeedMs] = useState(0)
+  const [maxSpeedMs, setMaxSpeedMs] = useState(0)
   const [distance, setDistance] = useState(0)
   const [error, setError] = useState<string | null>(null)
   const startTime = useRef(Date.now())
@@ -23,6 +24,7 @@ export default function useSpeed(unit: Unit) {
         pos => {
           const { speed, latitude, longitude } = pos.coords
           setSpeedMs(speed ?? 0)
+          setMaxSpeedMs(prev => Math.max(prev, speed ?? 0))
           if (lastPos.current) {
             const d = haversineDistance(
               lastPos.current.latitude,
@@ -47,6 +49,7 @@ export default function useSpeed(unit: Unit) {
 
   return {
     speed: convert(speedMs),
+    maxSpeed: convert(maxSpeedMs),
     distance,
     duration,
     avgSpeed: convert(avgSpeedMs),

--- a/src/components/free/TripSummary.jsx
+++ b/src/components/free/TripSummary.jsx
@@ -5,7 +5,7 @@ import { sweep } from '../../hooks/useAnimations'
 
 export default function TripSummary() {
   const { unit } = useUnit()
-  const { distance, duration, avgSpeed } = useSpeedContext()
+  const { distance, duration, avgSpeed, maxSpeed } = useSpeedContext()
   return (
     <motion.div
       className="p-4 space-y-1 text-sm"
@@ -20,6 +20,9 @@ export default function TripSummary() {
       <div>Duration: {Math.floor(duration)} s</div>
       <div>
         Avg speed: {avgSpeed.toFixed(1)} {unit === 'kmh' ? 'km/h' : 'mph'}
+      </div>
+      <div>
+        Max: {maxSpeed.toFixed(1)} {unit === 'kmh' ? 'km/h' : 'mph'}
       </div>
     </motion.div>
   )

--- a/src/components/free/__tests__/HUD.test.jsx
+++ b/src/components/free/__tests__/HUD.test.jsx
@@ -4,7 +4,7 @@ import SpeedHUD from '../../ui/SpeedHUD'
 import { UnitProvider } from '../../../context/UnitContext'
 
 jest.mock('../../../context/SpeedContext', () => ({
-  useSpeedContext: jest.fn(() => ({ speed: 0, distance: 0, duration: 0, avgSpeed: 0, error: null }))
+  useSpeedContext: jest.fn(() => ({ speed: 0, maxSpeed: 0, distance: 0, duration: 0, avgSpeed: 0, error: null }))
 }))
 
 test('renders speed display with unit', () => {

--- a/src/components/free/__tests__/SpeedAlert.test.jsx
+++ b/src/components/free/__tests__/SpeedAlert.test.jsx
@@ -11,7 +11,7 @@ jest.mock('../../../context/SpeedContext', () => ({
 const mockedUseSpeedContext = useSpeedContext
 
 test('shows warning when speed exceeds limit', () => {
-  mockedUseSpeedContext.mockReturnValue({ speed: 100 })
+  mockedUseSpeedContext.mockReturnValue({ speed: 100, maxSpeed: 100 })
   render(
     <UnitProvider>
       <SpeedAlert />

--- a/src/components/free/__tests__/TripSummary.test.jsx
+++ b/src/components/free/__tests__/TripSummary.test.jsx
@@ -11,7 +11,7 @@ jest.mock('../../../context/SpeedContext', () => ({
 const mockedUseSpeedContext = useSpeedContext
 
 test('renders trip stats', () => {
-  mockedUseSpeedContext.mockReturnValue({ distance: 2000, duration: 100, avgSpeed: 50 })
+  mockedUseSpeedContext.mockReturnValue({ distance: 2000, duration: 100, avgSpeed: 50, maxSpeed: 80 })
   render(
     <UnitProvider>
       <TripSummary />
@@ -20,4 +20,5 @@ test('renders trip stats', () => {
   expect(screen.getByText(/Distance:/)).toBeInTheDocument()
   expect(screen.getByText(/Duration:/)).toBeInTheDocument()
   expect(screen.getByText(/Avg speed/)).toBeInTheDocument()
+  expect(screen.getByText(/Max:/)).toBeInTheDocument()
 })

--- a/src/hooks/useSpeed.js
+++ b/src/hooks/useSpeed.js
@@ -3,6 +3,7 @@ import { haversineDistance } from '../utils/geo'
 
 export default function useSpeed(unit = 'kmh') {
   const [speedMs, setSpeedMs] = useState(0)
+  const [maxSpeedMs, setMaxSpeedMs] = useState(0)
   const [distance, setDistance] = useState(0) // meters
   const [error, setError] = useState(null)
   const startTime = useRef(Date.now())
@@ -13,6 +14,7 @@ export default function useSpeed(unit = 'kmh') {
       pos => {
         const { speed, latitude, longitude } = pos.coords
         setSpeedMs(speed || 0)
+        setMaxSpeedMs(prev => Math.max(prev, speed || 0))
         if (lastPos.current) {
           const d = haversineDistance(
             lastPos.current.latitude,
@@ -35,6 +37,7 @@ export default function useSpeed(unit = 'kmh') {
 
   return {
     speed: convert(speedMs),
+    maxSpeed: convert(maxSpeedMs),
     distance,
     duration,
     avgSpeed: convert(avgSpeedMs),


### PR DESCRIPTION
## Summary
- track max speed in `useSpeed` hooks
- expose `maxSpeed` in `SpeedContext`
- show max speed in trip summary components
- adjust related unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a13ac0cf08325ba544c17cc20d1e4