### PR TITLE
Add vibration feedback in mobile SpeedAlert

### DIFF
--- a/mobile/components/SpeedAlert.tsx
+++ b/mobile/components/SpeedAlert.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { View, TextInput, Text } from 'react-native'
+import { View, TextInput, Text, Vibration } from 'react-native'
 import { useUnit } from '../context/UnitContext'
 import { useSpeedContext } from '../context/SpeedContext'
 
@@ -8,6 +8,13 @@ export default function SpeedAlert() {
   const { speed } = useSpeedContext()
   const [limit, setLimit] = useState(unit === 'kmh' ? 80 : 50)
   const over = speed > limit
+  React.useEffect(() => {
+    if (over) {
+      Vibration.vibrate([0, 200])
+    } else {
+      Vibration.cancel()
+    }
+  }, [over])
   const unitLabel = unit === 'kmh' ? 'km/h' : 'mph'
   return (
     <View className="p-4">


### PR DESCRIPTION
## Summary
- vibrate phone using React Native Vibration when speed exceeds limit
- stop vibration when speed is back under limit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a13edce588325aff19e5964cc4126