### PR TITLE
Persist trip data across sessions

### DIFF
--- a/mobile/components/TripSummary.tsx
+++ b/mobile/components/TripSummary.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { View, Text } from 'react-native'
+import { View, Text, Button } from 'react-native'
 import { useUnit } from '../context/UnitContext'
 import { useSpeedContext } from '../context/SpeedContext'
 
 export default function TripSummary() {
   const { unit } = useUnit()
-  const { distance, duration, avgSpeed } = useSpeedContext()
+  const { distance, duration, avgSpeed, maxSpeed, clearTrip } = useSpeedContext()
   const dist = unit === 'kmh' ? distance / 1000 : distance / 1609.34
   const distUnit = unit === 'kmh' ? 'km' : 'mi'
   const speedUnit = unit === 'kmh' ? 'km/h' : 'mph'
@@ -14,6 +14,8 @@ export default function TripSummary() {
       <Text>Distance: {dist.toFixed(2)} {distUnit}</Text>
       <Text>Duration: {Math.floor(duration)} s</Text>
       <Text>Avg: {avgSpeed.toFixed(1)} {speedUnit}</Text>
+      <Text>Max: {maxSpeed.toFixed(1)} {speedUnit}</Text>
+      <Button title="Clear trip" onPress={clearTrip} />
     </View>
   )
 }

--- a/mobile/context/SpeedContext.tsx
+++ b/mobile/context/SpeedContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react'
+import React, { createContext, useContext, useState, useEffect } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import useSpeed from '../hooks/useSpeed'
 import { useUnit } from './UnitContext'
 
@@ -7,7 +8,9 @@ export interface SpeedData {
   distance: number
   duration: number
   avgSpeed: number
+  maxSpeed: number
   error: string | null
+  clearTrip: () => void
   setSpeed?: (v: number | null) => void
 }
 
@@ -17,9 +20,57 @@ export const SpeedProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const { unit } = useUnit()
   const data = useSpeed(unit)
   const [override, setOverride] = useState<number | null>(null)
+  const [baseDistance, setBaseDistance] = useState(0)
+  const [baseDuration, setBaseDuration] = useState(0)
+  const [maxSpeed, setMaxSpeed] = useState(0)
+
+  useEffect(() => {
+    ;(async () => {
+      const raw = await AsyncStorage.getItem('tripData')
+      if (raw) {
+        try {
+          const { distance = 0, duration = 0, maxSpeed = 0 } = JSON.parse(raw)
+          setBaseDistance(distance)
+          setBaseDuration(duration)
+          setMaxSpeed(maxSpeed)
+        } catch (e) {
+          // ignore
+        }
+      }
+    })()
+  }, [])
+
+  useEffect(() => {
+    setMaxSpeed(ms => Math.max(ms, data.speed))
+  }, [data.speed])
+
+  useEffect(() => {
+    return () => {
+      AsyncStorage.setItem(
+        'tripData',
+        JSON.stringify({
+          distance: baseDistance + data.distance,
+          duration: baseDuration + data.duration,
+          maxSpeed,
+        })
+      )
+    }
+  }, [baseDistance, baseDuration, data.distance, data.duration, maxSpeed])
+
+  const clearTrip = async () => {
+    await AsyncStorage.removeItem('tripData')
+    setBaseDistance(0)
+    setBaseDuration(0)
+    setMaxSpeed(0)
+  }
+
   const value = {
     ...data,
     speed: override !== null ? override : data.speed,
+    distance: baseDistance + data.distance,
+    duration: baseDuration + data.duration,
+    maxSpeed,
+    clearTrip,
     setSpeed: setOverride,
   }
   return <SpeedContext.Provider value={value}>{children}</SpeedContext.Provider>

--- a/src/components/free/TripSummary.jsx
+++ b/src/components/free/TripSummary.jsx
@@ -5,7 +5,7 @@ import { sweep } from '../../hooks/useAnimations'
 
 export default function TripSummary() {
   const { unit } = useUnit()
-  const { distance, duration, avgSpeed } = useSpeedContext()
+  const { distance, duration, avgSpeed, maxSpeed, clearTrip } = useSpeedContext()
   return (
     <motion.div
       className="p-4 space-y-1 text-sm"
@@ -21,6 +21,12 @@ export default function TripSummary() {
       <div>
         Avg speed: {avgSpeed.toFixed(1)} {unit === 'kmh' ? 'km/h' : 'mph'}
       </div>
+      <div>
+        Max speed: {maxSpeed.toFixed(1)} {unit === 'kmh' ? 'km/h' : 'mph'}
+      </div>
+      <button onClick={clearTrip} className="underline text-xs">
+        Clear trip
+      </button>
     </motion.div>
   )
 }

--- a/src/components/free/__tests__/TripSummary.test.jsx
+++ b/src/components/free/__tests__/TripSummary.test.jsx
@@ -11,7 +11,7 @@ jest.mock('../../../context/SpeedContext', () => ({
 const mockedUseSpeedContext = useSpeedContext
 
 test('renders trip stats', () => {
-  mockedUseSpeedContext.mockReturnValue({ distance: 2000, duration: 100, avgSpeed: 50 })
+  mockedUseSpeedContext.mockReturnValue({ distance: 2000, duration: 100, avgSpeed: 50, maxSpeed: 80, clearTrip: jest.fn() })
   render(
     <UnitProvider>
       <TripSummary />
@@ -20,4 +20,6 @@ test('renders trip stats', () => {
   expect(screen.getByText(/Distance:/)).toBeInTheDocument()
   expect(screen.getByText(/Duration:/)).toBeInTheDocument()
   expect(screen.getByText(/Avg speed/)).toBeInTheDocument()
+  expect(screen.getByText(/Max speed/)).toBeInTheDocument()
+  expect(screen.getByText(/Clear trip/)).toBeInTheDocument()
 })

--- a/src/context/SpeedContext.jsx
+++ b/src/context/SpeedContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useState, useEffect } from 'react'
 import useSpeed from '../hooks/useSpeed'
 import { useUnit } from './UnitContext'
 
@@ -8,9 +8,55 @@ export function SpeedProvider({ children }) {
   const { unit } = useUnit()
   const data = useSpeed(unit)
   const [override, setOverride] = useState(null)
+  const [baseDistance, setBaseDistance] = useState(0)
+  const [baseDuration, setBaseDuration] = useState(0)
+  const [maxSpeed, setMaxSpeed] = useState(0)
+
+  useEffect(() => {
+    const raw = localStorage.getItem('tripData')
+    if (raw) {
+      try {
+        const { distance = 0, duration = 0, maxSpeed = 0 } = JSON.parse(raw)
+        setBaseDistance(distance)
+        setBaseDuration(duration)
+        setMaxSpeed(maxSpeed)
+      } catch (e) {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    setMaxSpeed(ms => Math.max(ms, data.speed))
+  }, [data.speed])
+
+  useEffect(() => {
+    return () => {
+      localStorage.setItem(
+        'tripData',
+        JSON.stringify({
+          distance: baseDistance + data.distance,
+          duration: baseDuration + data.duration,
+          maxSpeed
+        })
+      )
+    }
+  }, [baseDistance, baseDuration, data.distance, data.duration, maxSpeed])
+
+  const clearTrip = () => {
+    localStorage.removeItem('tripData')
+    setBaseDistance(0)
+    setBaseDuration(0)
+    setMaxSpeed(0)
+  }
+
   const value = {
     ...data,
     speed: override !== null ? override : data.speed,
+    distance: baseDistance + data.distance,
+    duration: baseDuration + data.duration,
+    maxSpeed,
+    clearTrip,
     setSpeed: setOverride
   }
   return (


### PR DESCRIPTION
## Summary
- store trip data in web `localStorage` and mobile `AsyncStorage`
- load stored data on startup
- expose a `clearTrip` helper
- show max speed and a button to clear saved data in TripSummary
- update tests for new UI

## Testing
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_685a14c9fdb08325b6d80a17b498af90