### PR TITLE
Add voice command handling

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -8,15 +8,18 @@ import ThemeToggle from './components/ThemeToggle'
 import TripSummary from './components/TripSummary'
 import AdBanner from './components/AdBanner'
 import HUDToggle from './components/HUDToggle'
-import { UnitProvider } from './context/UnitContext'
+import { UnitProvider, useUnit } from './context/UnitContext'
 import { ThemeProvider, useTheme } from './context/ThemeContext'
 import { SpeedProvider } from './context/SpeedContext'
 import { HUDProvider, useHUD } from './context/HUDContext'
 import { StatusBar } from 'expo-status-bar'
+import useVoiceCommands from './hooks/useVoiceCommands'
 
 function Dashboard() {
   const { dark } = useTheme()
-  const { hud } = useHUD()
+  const { hud, toggleHUD } = useHUD()
+  const { toggleUnit } = useUnit()
+  useVoiceCommands(toggleHUD, toggleUnit)
   return (
     <SafeAreaView className={dark ? 'bg-black flex-1' : 'bg-white flex-1'}>
       {hud ? (

--- a/mobile/hooks/useVoiceCommands.ts
+++ b/mobile/hooks/useVoiceCommands.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import Voice from 'react-native-voice'
+
+export default function useVoiceCommands(
+  toggleHUD: () => void,
+  toggleUnit: () => void
+) {
+  useEffect(() => {
+    Voice.onSpeechResults = e => {
+      const text = e.value?.[0]?.toLowerCase() ?? ''
+      if (text.includes('hud')) toggleHUD()
+      if (text.includes('units')) toggleUnit()
+    }
+    Voice.start('en-US')
+    return () => {
+      Voice.destroy().then(Voice.removeAllListeners)
+    }
+  }, [toggleHUD, toggleUnit])
+}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -17,7 +17,8 @@
         "nativewind": "^4.1.23",
         "react": "19.0.0",
         "react-native": "0.79.4",
-        "react-native-svg": "^15.12.0"
+        "react-native-svg": "^15.12.0",
+        "react-native-voice": "^3.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -7635,6 +7636,15 @@
         "css-tree": "^1.1.3",
         "warn-once": "0.1.1"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-voice": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-voice/-/react-native-voice-3.2.0.tgz",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,7 +18,8 @@
     "nativewind": "^4.1.23",
     "react": "19.0.0",
     "react-native": "0.79.4",
-    "react-native-svg": "^15.12.0"
+    "react-native-svg": "^15.12.0",
+    "react-native-voice": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/free/FreeDashboard.jsx
+++ b/src/components/free/FreeDashboard.jsx
@@ -14,11 +14,14 @@ import { sweep } from '../../hooks/useAnimations'
 import { SpeedProvider, useSpeedContext } from '../../context/SpeedContext'
 import { useHUD } from '../../context/HUDContext'
 import { useUnit } from '../../context/UnitContext'
+import useVoiceCommands from '../../hooks/useVoiceCommands'
 
 function DashboardContent() {
   const { speed, setSpeed } = useSpeedContext()
   const { hud, toggleHUD } = useHUD()
   const { toggleUnit } = useUnit()
+
+  useVoiceCommands(toggleHUD, toggleUnit)
 
   React.useEffect(() => {
     function handle(e) {

--- a/src/hooks/useVoiceCommands.js
+++ b/src/hooks/useVoiceCommands.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+
+export default function useVoiceCommands(toggleHUD, toggleUnit) {
+  useEffect(() => {
+    const SpeechRecognition =
+      window.SpeechRecognition || window.webkitSpeechRecognition
+    if (!SpeechRecognition) return
+
+    const recognition = new SpeechRecognition()
+    recognition.continuous = true
+    recognition.onresult = e => {
+      const text = e.results[e.results.length - 1][0].transcript
+        .trim()
+        .toLowerCase()
+      if (text.includes('hud')) toggleHUD()
+      if (text.includes('units')) toggleUnit()
+    }
+    recognition.start()
+    return () => recognition.stop()
+  }, [toggleHUD, toggleUnit])
+}


### PR DESCRIPTION
## Summary
- add voice command hooks for web/mobile
- wire up voice commands in dashboards
- install `react-native-voice` for mobile

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a16112fd08325b3c7085e017404d3