### PR TITLE
Fix SpeedContext duplicates

### DIFF
--- a/mobile/components/TripSummary.tsx
+++ b/mobile/components/TripSummary.tsx
@@ -6,7 +6,6 @@ import { useSpeedContext } from '../context/SpeedContext'
 export default function TripSummary() {
   const { unit } = useUnit()
   const { distance, duration, avgSpeed, maxSpeed, clearTrip } = useSpeedContext()
-  const { distance, duration, avgSpeed, maxSpeed } = useSpeedContext()
   const dist = unit === 'kmh' ? distance / 1000 : distance / 1609.34
   const distUnit = unit === 'kmh' ? 'km' : 'mi'
   const speedUnit = unit === 'kmh' ? 'km/h' : 'mph'

--- a/mobile/context/SpeedContext.tsx
+++ b/mobile/context/SpeedContext.tsx
@@ -1,4 +1,3 @@
-import React, { createContext, useContext, useState } from 'react'
 import React, { createContext, useContext, useState, useEffect } from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import useSpeed from '../hooks/useSpeed'
@@ -10,7 +9,6 @@ export interface SpeedData {
   distance: number
   duration: number
   avgSpeed: number
-  maxSpeed: number
   error: string | null
   clearTrip: () => void
   setSpeed?: (v: number | null) => void
@@ -22,9 +20,6 @@ export const SpeedProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const { unit } = useUnit()
   const data = useSpeed(unit)
   const [override, setOverride] = useState<number | null>(null)
-  const value = {
-    ...data,
-    speed: override !== null ? override : data.speed,
   const [baseDistance, setBaseDistance] = useState(0)
   const [baseDuration, setBaseDuration] = useState(0)
   const [maxSpeed, setMaxSpeed] = useState(0)

--- a/src/components/free/TripSummary.jsx
+++ b/src/components/free/TripSummary.jsx
@@ -6,7 +6,6 @@ import { sweep } from '../../hooks/useAnimations'
 export default function TripSummary() {
   const { unit } = useUnit()
   const { distance, duration, avgSpeed, maxSpeed, clearTrip } = useSpeedContext()
-  const { distance, duration, avgSpeed, maxSpeed } = useSpeedContext()
   return (
     <motion.div
       className="p-4 space-y-1 text-sm"
@@ -28,8 +27,6 @@ export default function TripSummary() {
       <button onClick={clearTrip} className="underline text-xs">
         Clear trip
       </button>
-        Max: {maxSpeed.toFixed(1)} {unit === 'kmh' ? 'km/h' : 'mph'}
-      </div>
     </motion.div>
   )
 }

--- a/src/components/free/__tests__/TripSummary.test.jsx
+++ b/src/components/free/__tests__/TripSummary.test.jsx
@@ -12,7 +12,6 @@ const mockedUseSpeedContext = useSpeedContext
 
 test('renders trip stats', () => {
   mockedUseSpeedContext.mockReturnValue({ distance: 2000, duration: 100, avgSpeed: 50, maxSpeed: 80, clearTrip: jest.fn() })
-  mockedUseSpeedContext.mockReturnValue({ distance: 2000, duration: 100, avgSpeed: 50, maxSpeed: 80 })
   render(
     <UnitProvider>
       <TripSummary />
@@ -23,5 +22,4 @@ test('renders trip stats', () => {
   expect(screen.getByText(/Avg speed/)).toBeInTheDocument()
   expect(screen.getByText(/Max speed/)).toBeInTheDocument()
   expect(screen.getByText(/Clear trip/)).toBeInTheDocument()
-  expect(screen.getByText(/Max:/)).toBeInTheDocument()
 })

--- a/src/context/SpeedContext.jsx
+++ b/src/context/SpeedContext.jsx
@@ -1,4 +1,3 @@
-import { createContext, useContext, useState } from 'react'
 import { createContext, useContext, useState, useEffect } from 'react'
 import useSpeed from '../hooks/useSpeed'
 import { useUnit } from './UnitContext'
@@ -9,9 +8,6 @@ export function SpeedProvider({ children }) {
   const { unit } = useUnit()
   const data = useSpeed(unit)
   const [override, setOverride] = useState(null)
-  const value = {
-    ...data,
-    speed: override !== null ? override : data.speed,
   const [baseDistance, setBaseDistance] = useState(0)
   const [baseDuration, setBaseDuration] = useState(0)
   const [maxSpeed, setMaxSpeed] = useState(0)


### PR DESCRIPTION
## Summary
- clean up `SpeedContext` to remove duplicate imports and object definitions
- remove accidental duplicate call in `TripSummary`
- adjust affected tests
- update mobile sources to match

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a27b437fc8325915fadd7db51ea3f