### PR TITLE
Fix Expo dev client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ npm install
 
 ### Development
 
+This app uses native modules that aren't available in Expo Go. Use the Expo dev
+client instead:
+
 ```bash
-npx expo start
+npx expo run:android # or `npx expo run:ios`
 ```
 
 ### Production build

--- a/mobile/index.ts
+++ b/mobile/index.ts
@@ -2,7 +2,7 @@ import { registerRootComponent } from 'expo';
 
 import App from './App';
 
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App).
+// This app relies on native modules not included in Expo Go, so be sure to run
+// it with a custom dev client using `npx expo run:android` or `npx expo run:ios`.
 registerRootComponent(App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "main": "index.ts",
   "scripts": {
-    "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "start": "expo start --dev-client",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web"
   },
   "dependencies": {
@@ -19,7 +19,9 @@
     "react": "19.0.0",
     "react-native": "0.79.4",
     "react-native-svg": "^15.12.0",
-    "react-native-voice": "^3.2.0"
+    "react-native-voice": "^3.2.0",
+    "@react-native-async-storage/async-storage": "^1.23.0",
+    "expo-dev-client": "^2.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- install Expo dev client and async storage modules
- update scripts to use `expo run:*`
- update index comment about using a custom dev client
- document how to run the mobile app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae3bac9fc83259a3bdac1e748c899