### PR TITLE
Add plugins to Expo Babel config

### DIFF
--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,6 +1,7 @@
 module.exports = function (api) {
   api.cache(true)
   return {
-    presets: ['babel-preset-expo', 'nativewind/babel'],
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel', 'react-native-reanimated/plugin'],
   }
 }


### PR DESCRIPTION
## Summary
- configure the mobile `babel.config.js` with `plugins`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685daa3a7f9883258f3c7b8621e70b4e